### PR TITLE
Containerize the web app

### DIFF
--- a/api/Dockerfile
+++ b/api/Dockerfile
@@ -1,0 +1,20 @@
+# Use python:3.9 as the base image
+FROM python:3.9
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy requirements.txt to the working directory
+COPY requirements.txt .
+
+# Run pip install -r requirements.txt to install dependencies
+RUN pip install -r requirements.txt
+
+# Copy the rest of the application code to the working directory
+COPY . .
+
+# Expose port 8000
+EXPOSE 8000
+
+# Set the command to run uvicorn main:app --host 0.0.0.0 --port 8000
+CMD ["uvicorn", "main:app", "--host", "0.0.0.0", "--port", "8000"]

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,18 @@
+version: '3.8'
+
+services:
+  frontend:
+    build:
+      context: ./frontend
+      dockerfile: Dockerfile
+    ports:
+      - "5173:5173"
+    depends_on:
+      - api
+
+  api:
+    build:
+      context: ./api
+      dockerfile: Dockerfile
+    ports:
+      - "8000:8000"

--- a/frontend/Dockerfile
+++ b/frontend/Dockerfile
@@ -1,0 +1,20 @@
+# Use node:18 as the base image
+FROM node:18
+
+# Set the working directory to /app
+WORKDIR /app
+
+# Copy package.json and package-lock.json to the working directory
+COPY package.json package-lock.json ./
+
+# Run npm install to install dependencies
+RUN npm install
+
+# Copy the rest of the application code to the working directory
+COPY . .
+
+# Expose port 5173
+EXPOSE 5173
+
+# Set the command to run npm run dev
+CMD ["npm", "run", "dev"]

--- a/frontend/src/routes/+layout.server.js
+++ b/frontend/src/routes/+layout.server.js
@@ -1,7 +1,6 @@
-// +layout.server.js
 export const load = async ({ fetch }) => {
     try {
-      const response = await fetch('http://localhost:8000/'); // Replace with your API URL
+      const response = await fetch('http://api:8000/'); // Replace with your API URL
       if (!response.ok) {
         throw new Error(`API returned status ${response.status}`);
       }
@@ -17,4 +16,3 @@ export const load = async ({ fetch }) => {
       };
     }
   };
-  


### PR DESCRIPTION
Add Docker support for the web app.

* **docker-compose.yml**: Define services for `frontend` and `api`, set `frontend` to build from `frontend/Dockerfile` and expose port 5173, set `api` to build from `api/Dockerfile` and expose port 8000.
* **frontend/Dockerfile**: Use `node:18` as the base image, set the working directory to `/app`, copy `package.json` and `package-lock.json` to the working directory, run `npm install` to install dependencies, copy the rest of the application code to the working directory, expose port 5173, set the command to run `npm run dev`.
* **api/Dockerfile**: Use `python:3.9` as the base image, set the working directory to `/app`, copy `requirements.txt` to the working directory, run `pip install -r requirements.txt` to install dependencies, copy the rest of the application code to the working directory, expose port 8000, set the command to run `uvicorn main:app --host 0.0.0.0 --port 8000`.
* **frontend/src/routes/+layout.server.js**: Update the API URL to `http://api:8000/`.

